### PR TITLE
refactor: :recycle: ConditionProbe as a proportion of visit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## v0.1.3 - 22-12-2022
+
+- ConditionProbe: Update, computed as a proportion of number of visit.
 ## v0.1.2 - 14-12-2022
 
 - ConditionProbe computes the availability of administrative data related to visits with at least one ICD-10 code recorded.

--- a/docs/components/probe.md
+++ b/docs/components/probe.md
@@ -202,19 +202,19 @@ We list hereafter the Probes that have already been implemented in the library.
 
 === "ConditionProbe"
 
-    The [``ConditionProbe``][edsteva.probes.condition.ConditionProbe] computes $c_{condition}(t)$ the availability of administrative data related to visits with at least one ICD-10 code recorded for each care site according to time:
+    The [``ConditionProbe``][edsteva.probes.condition.ConditionProbe] computes $c_{condition}(t)$ the availability of claim data linked to patients' stays:
 
     $$
-    c_{condition}(t) = \frac{n_{condition}(t)}{n_{99}}
+    c_{condition}(t) = \frac{n_{with\,condition}(t)}{n_{visit}(t)}
     $$
 
-    Where $n_{condition}(t)$ is the number of stays with at least one ICD-10 code recorded, $t$ is the month and $n_{99}$ is the $99^{th}$ percentile of $n_{condition}(t)$.
+    Where $n_{visit}(t)$ is the number of stays recorded, $n_{with\,condition}$ the number of stays having at least one claim code (e.g. ICD-10) recorded and $t$ is the month.
 
-    !!!info ""
-        If the $99^{th}$ percentile $n_{99}$ is equal to 0, we consider that the completeness predictor $c(t)$ is also equal to 0.
+    !!!Warning "Care site level"
+        This probe is only available at hospital level.
 
     ```python
-    from edsteva.probes import VisitProbe
+    from edsteva.probes import ConditionProbe
 
     condition = ConditionProbe()
     condition.compute(
@@ -235,10 +235,10 @@ We list hereafter the Probes that have already been implemented in the library.
     condition.predictor.head()
     ```
 
-    | care_site_level          | care_site_id | care_site_short_name | stay_type | diag_type | condition_type       | date       | n_visit | c     |
-    | :----------------------- | :----------- | :------------------- | :-------- | :-------- | :------------------- | :--------- | :------ | :---- |
-    | Unité Fonctionnelle (UF) | 8312056386   | Care site 1          | 'All'     | 'All'     | 'Pulmonary_embolism' | 2019-05-01 | 233.0   | 0.841 |
-    | Unité Fonctionnelle (UF) | 8312056386   | Care site 1          | 'All'     | 'DP/DR'   | 'Pulmonary_embolism' | 2021-04-01 | 393.0   | 0.640 |
-    | Pôle/DMU                 | 8312027648   | Care site 2          | 'Hospit'  | 'All'     | 'Pulmonary_embolism' | 2011-03-01 | 204.0   | 0.497 |
-    | Pôle/DMU                 | 8312027648   | Care site 2          | 'All'     | 'All'     | 'All'                | 2018-08-01 | 22.0    | 0.274 |
-    | Hôpital                  | 8312022130   | Care site 3          | 'Hospit'  | 'DP/DR'   | 'Pulmonary_embolism' | 2022-02-01 | 9746.0  | 0.769 |
+    | care_site_level | care_site_id | care_site_short_name | stay_type | diag_type | condition_type       | date       | n_visit | c     |
+    | :-------------- | :----------- | :------------------- | :-------- | :-------- | :------------------- | :--------- | :------ | :---- |
+    | Hôpital         | 8312057527   | Care site 1          | 'All'     | 'All'     | 'Pulmonary_embolism' | 2019-05-01 | 233.0   | 0.841 |
+    | Hôpital         | 8312057527   | Care site 1          | 'All'     | 'DP/DR'   | 'Pulmonary_embolism' | 2021-04-01 | 393.0   | 0.640 |
+    | Hôpital         | 8312027648   | Care site 2          | 'Hospit'  | 'All'     | 'Pulmonary_embolism' | 2011-03-01 | 204.0   | 0.497 |
+    | Hôpital         | 8312027648   | Care site 2          | 'All'     | 'All'     | 'All'                | 2018-08-01 | 22.0    | 0.274 |
+    | Hôpital         | 8312022130   | Care site 3          | 'Hospit'  | 'DP/DR'   | 'Pulmonary_embolism' | 2022-02-01 | 9746.0  | 0.769 |

--- a/docs/components/probe.md
+++ b/docs/components/probe.md
@@ -159,7 +159,7 @@ We list hereafter the Probes that have already been implemented in the library.
 
 === "NoteProbe"
 
-    The [``NoteProbe``][edsteva.probes.note.NoteProbe] computes $c_{note}(t)$ the availability of clinical documents linked to patients' visits:
+    The [``NoteProbe``][edsteva.probes.note.NoteProbe] computes $c_{note}(t)$ the availability of clinical documents linked to patients' administrative visit for each care site, stay type and note type according to time:
 
     $$
     c_{note}(t) = \frac{n_{with\,doc}(t)}{n_{visit}(t)}
@@ -194,21 +194,24 @@ We list hereafter the Probes that have already been implemented in the library.
 
     | care_site_level          | care_site_id | care_site_short_name | stay_type    | note_type             | date       | n_visit | c      |
     | :----------------------- | :----------- | :------------------- | :----------- | :-------------------- | :--------- | :------ | :----- |
-    | Unité Fonctionnelle (UF) | 8312056386   | Care site 1          | 'Urg_Hospit' | 'All'                 | 2019-05-01 | 233.0   | '0.841 |
+    | Unité Fonctionnelle (UF) | 8312056386   | Care site 1          | 'Urg'        | 'All'                 | 2019-05-01 | 233.0   | '0.841 |
     | Unité Fonctionnelle (UF) | 8653815660   | Care site 1          | 'All'        | 'CRH'                 | 2011-04-01 | 393.0   | 0.640  |
-    | Pôle/DMU                 | 8312027648   | Care site 2          | 'Urg'        | 'CRH'                 | 2021-03-01 | 204.0   | 0.497  |
+    | Pôle/DMU                 | 8312027648   | Care site 2          | 'Hospit'     | 'CRH'                 | 2021-03-01 | 204.0   | 0.497  |
     | Pôle/DMU                 | 8312056379   | Care site 2          | 'All'        | 'Ordonnance'          | 2018-08-01 | 22.0    | 0.274  |
-    | Hôpital                  | 8312022130   | Care site 3          | 'Hospit'     | 'CR Passage Urgences' | 2022-02-01 | 9746.0  | 0.769  |
+    | Hôpital                  | 8312022130   | Care site 3          | 'Urg_Hospit' | 'CR Passage Urgences' | 2022-02-01 | 9746.0  | 0.769  |
 
 === "ConditionProbe"
 
-    The [``ConditionProbe``][edsteva.probes.condition.ConditionProbe] computes $c_{condition}(t)$ the availability of claim data linked to patients' stays:
+    The [``ConditionProbe``][edsteva.probes.condition.ConditionProbe] computes $c_{condition}(t)$ the availability of claim data in patients' administrative visit for each care site, stay type, diag type and condition type according to time:
 
     $$
     c_{condition}(t) = \frac{n_{with\,condition}(t)}{n_{visit}(t)}
     $$
 
-    Where $n_{visit}(t)$ is the number of stays recorded, $n_{with\,condition}$ the number of stays having at least one claim code (e.g. ICD-10) recorded and $t$ is the month.
+    Where $n_{visit}(t)$ is the number of administrative stays, $n_{with\,condition}$ the number of stays having at least one claim code (e.g. ICD-10) recorded and $t$ is the month.
+
+    !!!info ""
+        If the number of visits $n_{visit}(t)$ is equal to 0, we consider that the completeness predictor $c(t)$ is also equal to 0.
 
     !!!Warning "Care site level"
         This probe is only available at hospital level.

--- a/docs/index.md
+++ b/docs/index.md
@@ -521,19 +521,19 @@ The working example above describes the canonical usage workflow. However, you w
 
     === "ConditionProbe"
 
-        The [``ConditionProbe``][edsteva.probes.condition.ConditionProbe] computes $c_{condition}(t)$ the availability of administrative data related to visits with at least one ICD-10 code recorded for each care site according to time:
+        The [``ConditionProbe``][edsteva.probes.condition.ConditionProbe] computes $c_{condition}(t)$ the availability of claim data linked to patients' stays:
 
         $$
-        c_{condition}(t) = \frac{n_{condition}(t)}{n_{99}}
+        c_{condition}(t) = \frac{n_{with\,condition}(t)}{n_{visit}(t)}
         $$
 
-        Where $n_{condition}(t)$ is the number of stays with at least one ICD-10 code recorded, $t$ is the month and $n_{99}$ is the $99^{th}$ percentile of $n_{condition}(t)$.
+        Where $n_{visit}(t)$ is the number of stays recorded, $n_{with\,condition}$ the number of stays having at least one claim code (e.g. ICD-10) recorded and $t$ is the month.
 
-        !!!info ""
-            If the $99^{th}$ percentile $n_{99}$ is equal to 0, we consider that the completeness predictor $c(t)$ is also equal to 0.
+        !!!Warning "Care site level"
+            This probe is only available at hospital level.
 
         ```python
-        from edsteva.probes import VisitProbe
+        from edsteva.probes import ConditionProbe
 
         condition = ConditionProbe()
         condition.compute(
@@ -554,13 +554,13 @@ The working example above describes the canonical usage workflow. However, you w
         condition.predictor.head()
         ```
 
-        | care_site_level          | care_site_id | care_site_short_name | stay_type | diag_type | condition_type       | date       | n_visit | c     |
-        | :----------------------- | :----------- | :------------------- | :-------- | :-------- | :------------------- | :--------- | :------ | :---- |
-        | Unité Fonctionnelle (UF) | 8312056386   | Care site 1          | 'All'     | 'All'     | 'Pulmonary_embolism' | 2019-05-01 | 233.0   | 0.841 |
-        | Unité Fonctionnelle (UF) | 8312056386   | Care site 1          | 'All'     | 'DP/DR'   | 'Pulmonary_embolism' | 2021-04-01 | 393.0   | 0.640 |
-        | Pôle/DMU                 | 8312027648   | Care site 2          | 'Hospit'  | 'All'     | 'Pulmonary_embolism' | 2011-03-01 | 204.0   | 0.497 |
-        | Pôle/DMU                 | 8312027648   | Care site 2          | 'All'     | 'All'     | 'All'                | 2018-08-01 | 22.0    | 0.274 |
-        | Hôpital                  | 8312022130   | Care site 3          | 'Hospit'  | 'DP/DR'   | 'Pulmonary_embolism' | 2022-02-01 | 9746.0  | 0.769 |
+        | care_site_level | care_site_id | care_site_short_name | stay_type | diag_type | condition_type       | date       | n_visit | c     |
+        | :-------------- | :----------- | :------------------- | :-------- | :-------- | :------------------- | :--------- | :------ | :---- |
+        | Hôpital         | 8312057527   | Care site 1          | 'All'     | 'All'     | 'Pulmonary_embolism' | 2019-05-01 | 233.0   | 0.841 |
+        | Hôpital         | 8312057527   | Care site 1          | 'All'     | 'DP/DR'   | 'Pulmonary_embolism' | 2021-04-01 | 393.0   | 0.640 |
+        | Hôpital         | 8312027648   | Care site 2          | 'Hospit'  | 'All'     | 'Pulmonary_embolism' | 2011-03-01 | 204.0   | 0.497 |
+        | Hôpital         | 8312027648   | Care site 2          | 'All'     | 'All'     | 'All'                | 2018-08-01 | 22.0    | 0.274 |
+        | Hôpital         | 8312022130   | Care site 3          | 'Hospit'  | 'DP/DR'   | 'Pulmonary_embolism' | 2022-02-01 | 9746.0  | 0.769 |
 
 === "Model"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -478,7 +478,7 @@ The working example above describes the canonical usage workflow. However, you w
 
     === "NoteProbe"
 
-        The [``NoteProbe``][edsteva.probes.note.NoteProbe] computes $c_{note}(t)$ the availability of clinical documents linked to patients' visits for each care site, stay type and note type according to time:
+        The [``NoteProbe``][edsteva.probes.note.NoteProbe] computes $c_{note}(t)$ the availability of clinical documents linked to patients' administrative visit for each care site, stay type and note type according to time:
 
         $$
         c_{note}(t) = \frac{n_{with\,doc}(t)}{n_{visit}(t)}
@@ -521,13 +521,16 @@ The working example above describes the canonical usage workflow. However, you w
 
     === "ConditionProbe"
 
-        The [``ConditionProbe``][edsteva.probes.condition.ConditionProbe] computes $c_{condition}(t)$ the availability of claim data linked to patients' stays:
+        The [``ConditionProbe``][edsteva.probes.condition.ConditionProbe] computes $c_{condition}(t)$ the availability of claim data in patients' administrative visit for each care site, stay type, diag type and condition type according to time:
 
         $$
         c_{condition}(t) = \frac{n_{with\,condition}(t)}{n_{visit}(t)}
         $$
 
-        Where $n_{visit}(t)$ is the number of stays recorded, $n_{with\,condition}$ the number of stays having at least one claim code (e.g. ICD-10) recorded and $t$ is the month.
+        Where $n_{visit}(t)$ is the number of administrative stays, $n_{with\,condition}$ the number of stays having at least one claim code (e.g. ICD-10) recorded and $t$ is the month.
+
+        !!!info ""
+            If the number of visits $n_{visit}(t)$ is equal to 0, we consider that the completeness predictor $c(t)$ is also equal to 0.
 
         !!!Warning "Care site level"
             This probe is only available at hospital level.

--- a/edsteva/io/hive.py
+++ b/edsteva/io/hive.py
@@ -8,6 +8,8 @@ from pyspark.sql import DataFrame as SparkDataFrame
 from pyspark.sql import SparkSession
 from pyspark.sql.types import LongType, StructField, StructType
 
+from edsteva import koalas_options
+
 from . import settings
 from .i2b2_mapping import get_i2b2_table
 
@@ -100,6 +102,7 @@ class HiveData:  # pragma: no cover
         if spark_session is not None:
             self.spark_session = spark_session
         else:
+            koalas_options()
             logger.warning(
                 """
                 To improve performances when using Spark and Koalas, please call `edsteva.improve_performances()`

--- a/edsteva/probes/condition.py
+++ b/edsteva/probes/condition.py
@@ -100,13 +100,13 @@ def get_hospital_visit(condition_occurrence, visit_occurrence, care_site, source
 
 class ConditionProbe(BaseProbe):
     r"""
-    The ``ConditionProbe`` computes $c(t)$ the availability of claim data linked to patients' stays:
+    The [``ConditionProbe``][edsteva.probes.condition.ConditionProbe] computes $c_{condition}(t)$ the availability of claim data in patients' administrative stay:
 
     $$
-    c(t) = \frac{n_{with\,condition}(t)}{n_{visit}(t)}
+    c_{condition}(t) = \frac{n_{with\,condition}(t)}{n_{visit}(t)}
     $$
 
-    Where $n_{visit}(t)$ is the number of stays recorded, $n_{with\,condition}$ the number of stays having at least one claim code recorded and $t$ is the month.
+    Where $n_{visit}(t)$ is the number of administrative stays, $n_{with\,condition}$ the number of stays having at least one claim code (e.g. ICD-10) recorded and $t$ is the month.
 
     Attributes
     ----------

--- a/edsteva/probes/note.py
+++ b/edsteva/probes/note.py
@@ -174,7 +174,7 @@ def get_pole_visit(uf_visit, care_site, care_site_relationship):  # pragma: no c
 
 class NoteProbe(BaseProbe):
     r"""
-    The ``NoteProbe`` computes $c(t)$ the availability of clinical documents linked to patients' visits:
+    The ``NoteProbe`` computes $c(t)$ the availability of clinical documents linked to patients' administrative visit:
 
     $$
     c(t) = \frac{n_{with\,doc}(t)}{n_{visit}(t)}

--- a/edsteva/probes/note.py
+++ b/edsteva/probes/note.py
@@ -33,6 +33,7 @@ def compute_completeness(note_predictor):
         note_predictor.groupby(
             partition_cols,
             as_index=False,
+            dropna=False,
         )
         .agg({"has_note": "count"})
         .rename(columns={"has_note": "n_visit_with_note"})
@@ -43,6 +44,7 @@ def compute_completeness(note_predictor):
         note_predictor.groupby(
             partition_cols,
             as_index=False,
+            dropna=False,
         )
         .agg({"visit_id": "nunique"})
         .rename(columns={"visit_id": "n_visit"})

--- a/edsteva/probes/utils.py
+++ b/edsteva/probes/utils.py
@@ -74,7 +74,6 @@ def prepare_visit_occurrence(data, start_date, end_date, stay_types):
 
 def prepare_condition_occurrence(
     data: Data,
-    visit_occurrence: DataFrame,
     extra_data: Data,
     source: str,
     diag_types: List[str],
@@ -143,25 +142,6 @@ def prepare_condition_occurrence(
             table_name="condition_occurrence",
             type_groups=condition_types,
             name="condition_type",
-        )
-
-    # visit/condition linkage
-    if source == "AREM":
-        # Link with visit_occurrence_source_value
-        condition_occurrence = condition_occurrence.drop_duplicates(
-            ["visit_occurrence_source_value", "diag_type", "condition_type"]
-        )
-        condition_occurrence = condition_occurrence.merge(
-            visit_occurrence,
-            on="visit_occurrence_source_value",
-        ).drop(columns="visit_occurrence_source_value")
-    else:
-        condition_occurrence = condition_occurrence.drop_duplicates(
-            ["visit_occurrence_id", "diag_type", "condition_type"]
-        )
-        condition_occurrence = condition_occurrence.merge(
-            visit_occurrence,
-            on="visit_occurrence_id",
         )
 
     return condition_occurrence

--- a/edsteva/probes/visit.py
+++ b/edsteva/probes/visit.py
@@ -33,7 +33,7 @@ def compute_completeness(visit_predictor):
             as_index=False,
             dropna=False,
         )
-        .agg({"visit_id": "count"})
+        .agg({"visit_id": "nunique"})
         .rename(columns={"visit_id": "n_visit"})
     )
 


### PR DESCRIPTION
Refacto of the ConditionProbe.

## Description

ConditionProbe is now seen as a proportion as the number of visit
$$
c_{condition}(t) = \frac{n_{with\,condition}(t)}{n_{visit}(t)}
$$

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
