### PR TITLE
Fix: Completeness greater than one (Specific variable are not dropped when needed)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 ## Unreleased - 16-10-2023
-- Fix partitions cols issue, now each probes have specific partitions columns attribute
+- Fix partition columns issue, now each probes have specific partition columns attribute
 
 ## v0.2.7 - 20-09-2023
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 ## Unreleased - 16-10-2023
-- Fix partition columns issue, now each probes have specific partition columns attribute
 
+- Fix partition columns issue, now each probes have specific partition columns attribute
 ## v0.2.7 - 20-09-2023
 
 - Add new test for BiologyProbe

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased - 16-10-2023
+- Fix partitions cols issue, now each probes have specific partitions columns attribute
+
 ## v0.2.7 - 20-09-2023
 
 - Add new test for BiologyProbe


### PR DESCRIPTION
Completeness greater than one

## Description

Need to remove column from a drop duplicate when it is not used

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
